### PR TITLE
Fixing up incorrect Readme usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For examples on how to use this, check out the [gajira-demo](https://github.com/
 ```yaml
 - name: Create
   id: create
-  uses: ./atlassian/gajira-create@master
+  uses: atlassian/gajira-create@master
   with:
     project: GA
     issuetype: Build


### PR DESCRIPTION
The Readme is incorrectly setup here. Using the values in the readme cause the virtual machine to search for the package in the virtual environment rather than downloading the latest from Github. This is the error you get when using the values from the readme:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/GithubActionTest/GithubActionTest/atlassian/gajira-create@master'. Did you forget to run actions/checkout before running your local action?
```

Removing the `./` fixes this.